### PR TITLE
docs: simplify installation manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,11 @@ sequenceDiagram
 ## Installation
 
 ### Installing from Source Code
-1. Clone the repository:
-```bash
-git clone https://github.com/tienanr/docurift.git
-cd docurift
-```
 
-2. Build and install:
+Clone, build and install into $GOBIN ($GOPATH/bin or $HOME/go/bin):
+
 ```bash
-go build ./cmd/docurift
-go install ./cmd/docurift
+go install github.com/tienanr/docurift/cmd/docurift@latest
 ```
 
 ## Quick Start


### PR DESCRIPTION
We can simplify installation from source by using just `go install` instead of `git clone + go build + go install`

```
$ go help install
usage: go install [build flags] [packages]

Install compiles and installs the packages named by the import paths.

Executables are installed in the directory named by the GOBIN environment
variable, which defaults to $GOPATH/bin or $HOME/go/bin if the GOPATH
environment variable is not set. Executables in $GOROOT
are installed in $GOROOT/bin or $GOTOOLDIR instead of $GOBIN.
```