### PR TITLE
config file and redacted fields support

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test ./internal/... ./cmd/... -v
+        run: go test ./internal/... -v
 
       - name: Run staticcheck
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,52 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    main: ./cmd/docurift
+    binary: docurift
+    dir: .
+    ldflags:
+      - -s -w
+      - -X github.com/tienanr/docurift/cmd/docurift.version={{.Version}}
+      - -X github.com/tienanr/docurift/cmd/docurift.commit={{.ShortCommit}}
+      - -X github.com/tienanr/docurift/cmd/docurift.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - README.md
+      - config.yaml
+      - examples/
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: build build-dev clean
+
+# Version information
+VERSION ?= v0.1.4
+COMMIT ?= $(shell git rev-parse --short HEAD)
+DATE ?= $(shell date -u +'%Y-%m-%d_%H:%M:%S')
+
+# Build flags
+LDFLAGS = -X github.com/tienanr/docurift/cmd/docurift.version=$(VERSION) \
+          -X github.com/tienanr/docurift/cmd/docurift.commit=$(COMMIT) \
+          -X github.com/tienanr/docurift/cmd/docurift.date=$(DATE)
+
+# Build the application with version information
+build:
+	go build -ldflags "$(LDFLAGS)" -o docurift ./cmd/docurift
+
+# Build for development (without version information)
+build-dev:
+	go build -o docurift ./cmd/docurift
+
+# Clean build artifacts
+clean:
+	rm -f docurift 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,23 @@ go install github.com/tienanr/docurift/cmd/docurift@latest
 
 ## Quick Start
 
-1. Start DocuRift with your desired configuration:
-```bash
-./docurift -proxy-port 9876 -analyzer-port 9877 -backend-url http://localhost:8080 -max-examples 20
-```
-Note: backend url should be where your backend is running.
+1. Create a configuration file (e.g., `config.yaml`):
+```yaml
+proxy:
+    port: 9876
+    backend-url: http://localhost:8080
 
-2. Start your API server (example using the included shop API) on port 8080 and send test traffic:
+analyzer:
+    port: 9877
+    max-examples: 20
+```
+
+2. Start DocuRift with your configuration:
+```bash
+docurift -config config.yaml
+```
+
+3. Start your API server (example using the included shop API) on port 8080 and send test traffic:
 ```bash
 cd examples/shop
 lsof -ti :8080 | xargs kill
@@ -55,19 +65,35 @@ sleep 3
 go test -count=1 .
 ```
 
-3. Access your automatically generated documentation at http://localhost:9877/ (Swagger UI)
+4. Access your automatically generated documentation at http://localhost:9877/ (Swagger UI)
 
-4. Get open API spec: http://localhost:9877/openapi.json and Postman Collection: http://localhost:9877/postman.json
+5. Get open API spec: http://localhost:9877/openapi.json and Postman Collection: http://localhost:9877/postman.json
 
-## Configuration Options
+## Configuration
 
-- `-proxy-port`: Proxy server port (default: 9876)
-- `-analyzer-port`: Analyzer server port (default: 9877)
-- `-backend-url`: Backend API URL (default: http://localhost:8080)
-- `-max-examples`: Maximum number of examples per endpoint (default: 10)
+DocuRift uses a YAML configuration file to control its behavior. Here's the complete configuration reference:
+
+### Proxy Section
+- `port`: The port number that DocuRift's proxy server will listen on (e.g. 9876), point your clients request to this port instead of the real backend.
+- `backend-url`: The URL of your backend service that DocuRift will forward requests to.
+
+### Analyzer Section  
+- `port`: The port number for DocuRift's analyzer API endpoint (e.g. 9877)
+- `max-examples`: Maximum number of example values to store for each field in the schema
+
+Example configuration:
+```yaml
+proxy:
+    port: 9876
+    backend-url: http://localhost:8080
+
+analyzer:
+    port: 9877
+    max-examples: 10
+```
 
 ## Examples
-`
+
 Check out the `examples` directory for sample implementations:
 - `examples/shop`: A complete e-commerce API with various endpoints
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ proxy:
 analyzer:
     port: 9877
     max-examples: 20
+    redacted-fields:
+        - password
 ```
 
 2. Start DocuRift with your configuration:
@@ -80,6 +82,8 @@ DocuRift uses a YAML configuration file to control its behavior. Here's the comp
 ### Analyzer Section  
 - `port`: The port number for DocuRift's analyzer API endpoint (e.g. 9877)
 - `max-examples`: Maximum number of example values to store for each field in the schema
+- `redacted-fields`: A list of fields to redact in the documentation. Their values will be shown as "REDACTED" (e.g. authorization headers, API keys, passwords). This applies globally to HTTP headers, URL parameters and JSON fields.
+
 
 Example configuration:
 ```yaml

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+proxy:
+    port: 9876
+    backend-url: http://localhost:8080
+
+analyzer:
+    port: 9877
+    max-examples: 10

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,26 @@
+Configuration file can be specified as:
+```sh
+docurift -config config.yaml
+```
+
+Here is an example of DocuRift config file
+
+```yaml
+proxy:
+    port: 9876
+    backend-url: http://localhost:8080
+
+analyzer:
+    port: 9877
+    max-examples: 10
+```
+
+The configuration file controls DocuRift's behavior:
+
+### Proxy Section
+- `port`: The port number that DocuRift's proxy server will listen on (e.g. 9876)
+- `backend-url`: The URL of your backend service that DocuRift will forward requests to
+
+### Analyzer Section  
+- `port`: The port number for DocuRift's analyzer API endpoint (e.g. 9877)
+- `max-examples`: Maximum number of example values to store for each field in the schema

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,10 @@ proxy:
 analyzer:
     port: 9877
     max-examples: 10
+    redacted-fields:
+        - Authorization
+        - api_key
+        - password
 ```
 
 The configuration file controls DocuRift's behavior:
@@ -24,3 +28,4 @@ The configuration file controls DocuRift's behavior:
 ### Analyzer Section  
 - `port`: The port number for DocuRift's analyzer API endpoint (e.g. 9877)
 - `max-examples`: Maximum number of example values to store for each field in the schema
+- `redacted-fields`: A list of the fields to redact in the documentation. Their values will be shown as "REDACTED" (e.g. authorization header or api_keys that you don't want to expose in the doc) 

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -383,6 +383,9 @@ func (a *Analyzer) ProcessRequest(method, url string, req *http.Request, resp *h
 			Headers: NewSchemaStore(),
 			Payload: NewSchemaStore(),
 		}
+		// Set analyzer reference for response schema stores
+		responseData.Headers.SetAnalyzer(a)
+		responseData.Payload.SetAnalyzer(a)
 		endpoint.ResponseStatuses[status] = responseData
 	}
 	a.mu.Unlock()

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -242,8 +242,6 @@ var sensitivePatterns = map[string]string{
 	`^[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}$`: "4111-1111-1111-1111",
 	// SSN pattern
 	`^[0-9]{3}[- ]?[0-9]{2}[- ]?[0-9]{4}$`: "123-45-6789",
-	// Password pattern (any string containing "password" or "pass" or "pwd")
-	`(?i).*(password|pass|pwd).*`: "********",
 }
 
 // sanitizeValue replaces sensitive data with dummy values

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -18,6 +18,7 @@ type SchemaStore struct {
 	Examples    map[string][]interface{} // path -> []values
 	Optional    map[string]bool          // path -> isOptional
 	maxExamples int                      // Maximum number of examples to keep per field
+	analyzer    *Analyzer                // Reference to parent analyzer for accessing noExampleFields
 }
 
 // NewSchemaStore creates a new SchemaStore
@@ -29,10 +30,22 @@ func NewSchemaStore() *SchemaStore {
 	}
 }
 
+// SetAnalyzer sets the parent analyzer reference
+func (s *SchemaStore) SetAnalyzer(a *Analyzer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.analyzer = a
+}
+
 // AddValue adds a value to the schema store for a given path
 func (s *SchemaStore) AddValue(path string, value interface{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// If this is a redacted field, store "REDACTED" instead of the actual value
+	if s.analyzer != nil && s.analyzer.shouldRedact(path) {
+		value = "REDACTED"
+	}
 
 	if _, exists := s.Examples[path]; !exists {
 		s.Examples[path] = make([]interface{}, 0)
@@ -162,16 +175,18 @@ type ResponseData struct {
 
 // Analyzer is the main analyzer structure
 type Analyzer struct {
-	mu          sync.RWMutex
-	endpoints   map[string]*EndpointData // key: method+url
-	maxExamples int                      // Maximum number of examples to keep per field
+	mu             sync.RWMutex
+	endpoints      map[string]*EndpointData // key: method+url
+	maxExamples    int                      // Maximum number of examples to keep per field
+	redactedFields []string                 // Fields to redact in documentation
 }
 
 // NewAnalyzer creates a new Analyzer instance
 func NewAnalyzer() *Analyzer {
 	return &Analyzer{
-		endpoints:   make(map[string]*EndpointData),
-		maxExamples: 10, // Default value
+		endpoints:      make(map[string]*EndpointData),
+		maxExamples:    10, // Default value
+		redactedFields: make([]string, 0),
 	}
 }
 
@@ -180,6 +195,25 @@ func (a *Analyzer) SetMaxExamples(max int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.maxExamples = max
+}
+
+// SetRedactedFields sets the list of fields to redact in documentation
+func (a *Analyzer) SetRedactedFields(fields []string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.redactedFields = fields
+}
+
+// shouldRedact checks if a field should be redacted
+func (a *Analyzer) shouldRedact(field string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, redactedField := range a.redactedFields {
+		if strings.EqualFold(field, redactedField) {
+			return true
+		}
+	}
+	return false
 }
 
 // Common HTTP headers to exclude from documentation
@@ -308,6 +342,10 @@ func (a *Analyzer) ProcessRequest(method, url string, req *http.Request, resp *h
 			URLParameters:    NewSchemaStore(), // Initialize URL parameters store
 			ResponseStatuses: make(map[int]*ResponseData),
 		}
+		// Set analyzer reference for all schema stores
+		endpoint.RequestHeaders.SetAnalyzer(a)
+		endpoint.RequestPayload.SetAnalyzer(a)
+		endpoint.URLParameters.SetAnalyzer(a)
 		a.endpoints[key] = endpoint
 	}
 	a.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	minPort = 1
+	maxPort = 65535
+)
+
+// Config represents the DocuRift configuration structure
+type Config struct {
+	Proxy struct {
+		Port       int    `yaml:"port"`
+		BackendURL string `yaml:"backend-url"`
+	} `yaml:"proxy"`
+
+	Analyzer struct {
+		Port        int `yaml:"port"`
+		MaxExamples int `yaml:"max-examples"`
+	} `yaml:"analyzer"`
+}
+
+// validatePort checks if the port is within valid range
+func validatePort(port int, service string) error {
+	if port < minPort || port > maxPort {
+		return fmt.Errorf("%s port must be between %d and %d", service, minPort, maxPort)
+	}
+	return nil
+}
+
+// LoadConfig loads the configuration from the specified file path
+func LoadConfig(configPath string) (*Config, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config file: %w", err)
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("error parsing config file: %w", err)
+	}
+
+	// Validate proxy port
+	if err := validatePort(config.Proxy.Port, "proxy"); err != nil {
+		return nil, err
+	}
+
+	// Validate analyzer port
+	if err := validatePort(config.Analyzer.Port, "analyzer"); err != nil {
+		return nil, err
+	}
+
+	// Check for port conflict
+	if config.Proxy.Port == config.Analyzer.Port {
+		return nil, fmt.Errorf("proxy and analyzer cannot use the same port (%d)", config.Proxy.Port)
+	}
+
+	// Validate other required fields
+	if config.Proxy.BackendURL == "" {
+		return nil, fmt.Errorf("backend-url is required")
+	}
+	if config.Analyzer.MaxExamples <= 0 {
+		return nil, fmt.Errorf("max-examples must be greater than 0")
+	}
+
+	return &config, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,8 +20,9 @@ type Config struct {
 	} `yaml:"proxy"`
 
 	Analyzer struct {
-		Port        int `yaml:"port"`
-		MaxExamples int `yaml:"max-examples"`
+		Port            int      `yaml:"port"`
+		MaxExamples     int      `yaml:"max-examples"`
+		NoExampleFields []string `yaml:"no-example-fields"`
 	} `yaml:"analyzer"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// Create a temporary config file
+	configContent := `
+proxy:
+    port: 9876
+    backend-url: http://localhost:8080
+
+analyzer:
+    port: 9877
+    max-examples: 10
+`
+	tmpfile, err := os.CreateTemp("", "config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(configContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test loading valid config
+	config, err := LoadConfig(tmpfile.Name())
+	assert.NoError(t, err)
+	assert.NotNil(t, config)
+	assert.Equal(t, 9876, config.Proxy.Port)
+	assert.Equal(t, "http://localhost:8080", config.Proxy.BackendURL)
+	assert.Equal(t, 9877, config.Analyzer.Port)
+	assert.Equal(t, 10, config.Analyzer.MaxExamples)
+
+	// Test cases for invalid configurations
+	testCases := []struct {
+		name     string
+		config   string
+		errorMsg string
+	}{
+		{
+			name: "invalid proxy port range",
+			config: `
+proxy:
+    port: 70000
+    backend-url: http://localhost:8080
+analyzer:
+    port: 9877
+    max-examples: 10
+`,
+			errorMsg: "proxy port must be between 1 and 65535",
+		},
+		{
+			name: "invalid analyzer port range",
+			config: `
+proxy:
+    port: 9876
+    backend-url: http://localhost:8080
+analyzer:
+    port: 0
+    max-examples: 10
+`,
+			errorMsg: "analyzer port must be between 1 and 65535",
+		},
+		{
+			name: "port conflict",
+			config: `
+proxy:
+    port: 9876
+    backend-url: http://localhost:8080
+analyzer:
+    port: 9876
+    max-examples: 10
+`,
+			errorMsg: "proxy and analyzer cannot use the same port (9876)",
+		},
+		{
+			name: "missing backend url",
+			config: `
+proxy:
+    port: 9876
+    backend-url: ""
+analyzer:
+    port: 9877
+    max-examples: 10
+`,
+			errorMsg: "backend-url is required",
+		},
+		{
+			name: "invalid max examples",
+			config: `
+proxy:
+    port: 9876
+    backend-url: http://localhost:8080
+analyzer:
+    port: 9877
+    max-examples: 0
+`,
+			errorMsg: "max-examples must be greater than 0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(tmpfile.Name(), []byte(tc.config), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := LoadConfig(tmpfile.Name())
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errorMsg)
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,9 @@ proxy:
 analyzer:
     port: 9877
     max-examples: 10
+    no-example-fields:
+        - Authorization
+        - api_key
 `
 	tmpfile, err := os.CreateTemp("", "config-*.yaml")
 	if err != nil {
@@ -39,6 +42,7 @@ analyzer:
 	assert.Equal(t, "http://localhost:8080", config.Proxy.BackendURL)
 	assert.Equal(t, 9877, config.Analyzer.Port)
 	assert.Equal(t, 10, config.Analyzer.MaxExamples)
+	assert.Equal(t, []string{"Authorization", "api_key"}, config.Analyzer.NoExampleFields)
 
 	// Test cases for invalid configurations
 	testCases := []struct {

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /app
 RUN apk add --no-cache curl jq diffutils
 
 # Copy test files
-
 COPY test/run_tests.sh /usr/local/bin/run_tests.sh
 COPY test/expected_openapi.json /app/expected_openapi.json
+COPY test/config.yaml /app/config.yaml
 COPY go.mod go.sum ./
 COPY examples/shop/ ./shop
 

--- a/test/Dockerfile.docurift
+++ b/test/Dockerfile.docurift
@@ -12,10 +12,14 @@ RUN go mod download
 # Copy the DocuRift source code
 COPY ../../cmd/docurift ./cmd/docurift
 COPY ../../internal/analyzer ./internal/analyzer
+COPY ../../internal/config ./internal/config
 
 # Build DocuRift
 RUN go build -o docurift ./cmd/docurift
 
+# Copy config file
+COPY test/config.yaml /app/config.yaml
+
 EXPOSE 9876 9877
 
-CMD ["/app/docurift", "-proxy-port", "9876", "-analyzer-port", "9877", "-backend-url", "http://backend:8080", "-max-examples", "20"] 
+CMD ["/app/docurift", "-config", "/app/config.yaml"] 

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,0 +1,7 @@
+proxy:
+    port: 9876
+    backend-url: http://backend:8080
+
+analyzer:
+    port: 9877
+    max-examples: 20 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     environment:
       - CONFIG_PATH=/app/config.yaml
     volumes:
-      - ../config.yaml:/app/config.yaml:ro
+      - ./config.yaml:/app/config.yaml:ro
     networks:
       - docurift-network
     healthcheck:

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Set default values for environment variables
+BACKEND_URL=${BACKEND_URL:-"http://backend:8080"}
+ANALYZER_URL=${ANALYZER_URL:-"http://docurift:9877"}
+
 echo "Waiting for services to be ready..."
 
 # Wait for backend


### PR DESCRIPTION
* switch from command line options to config file in YAML
* add `redacted-fields` to allow users to redact fields from example collection (e.g. auth header, api key)
* add release files